### PR TITLE
Add CSV creation helper and auto-generation

### DIFF
--- a/Classificazione/csv_config.py
+++ b/Classificazione/csv_config.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 
 # Dati sperimentali in un dizionario
 class_attributes = {
@@ -132,7 +133,33 @@ class_attributes = {
     ]
 }
 
-# Creiamo il DataFrame a partire dal dizionario
-df = pd.DataFrame(class_attributes["Esperimenti"])
-# Salviamo il DataFrame normalizzato su un file CSV (opzionale, se desideri averlo su disco)
-df.to_csv("esperimenti.csv", index=False)
+
+def create_csv(csv_path: str | Path | None = None) -> Path:
+    """Generate the ``esperimenti.csv`` file.
+
+    Parameters
+    ----------
+    csv_path: str | Path | None, optional
+        Destination path for the CSV.  If ``None`` the file is written in the
+        project root.
+
+    Returns
+    -------
+    pathlib.Path
+        The full path of the generated CSV file.
+    """
+
+    df = pd.DataFrame(class_attributes["Esperimenti"])
+
+    if csv_path is None:
+        csv_path = Path(__file__).resolve().parent.parent / "esperimenti.csv"
+    else:
+        csv_path = Path(csv_path)
+
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+if __name__ == "__main__":
+    path = create_csv()
+    print(f"✅ File CSV creato: {path}")

--- a/Classificazione/dataset_organization.py
+++ b/Classificazione/dataset_organization.py
@@ -9,6 +9,7 @@ import tensorflow as tf  # Per pipeline di immagini e modelli TensorFlow
 from matplotlib import pyplot as plt  # Per visualizzare immagini
 from tensorflow.keras import layers, models
 from pathlib import Path
+from . import csv_config
 
 
 
@@ -236,10 +237,10 @@ def get_dataset(attributo):
 
     download_and_extract()  # Scarica ed estrae le immagini ESPERIMENTI se non già presenti
 
-    # Controlla che il file CSV esista
+    # Controlla che il file CSV esista altrimenti lo genera
     if not CSV_FILE.exists():
-        print(f"❌ Errore: File CSV '{CSV_FILE}' non trovato.")
-        sys.exit(1)
+        print(f"⚠️ File CSV '{CSV_FILE}' non trovato. Creazione in corso...")
+        csv_config.create_csv(CSV_FILE)
 
     #Legge il CSV e salva nel dataframe pandas
     #ora conterrà gli ID degli esperimenti (es:EXP01,EXP02...) e tutti i loro attributi (es.temperatura,...)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ This repository collects machine learning utilities for image classification and
    ```bash
    pip install -r requirements.txt
    ```
-2. Generate `esperimenti.csv` if it is not present:
-   ```bash
-   python Classificazione/csv_config.py
-   ```
-3. Run the classification models, for example:
+2. Run the classification models. The dataset utilities will
+   automatically create `esperimenti.csv` the first time you run them.
+   For example:
    ```bash
    python -m Classificazione.CNN.model_temperatura
    ```


### PR DESCRIPTION
## Summary
- add `create_csv` function to `csv_config`
- generate `esperimenti.csv` automatically in dataset utilities
- streamline README quick start instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a0a5a86c8332a04656d67df08085