### PR TITLE
Add optional data augmentation to dataset loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ This repository collects machine learning utilities for image classification and
    Replace `model_temperatura` with the desired module (e.g. `model_tempo`, `model_raffreddamento`, ...).
 
 The repository also provides an optional pre‑commit configuration in `Setup/Formattazione commit/` which formats Python files with **black** and **isort**.
+
+## Data augmentation
+
+Both dataset helpers expose an `augment` flag to enable random rotations, flips and brightness/contrast adjustments during training. Pass `augment=True` to `common.dataset_organization.get_dataset` or `Segmentazione.CNN.Dataset.create_dataset_from_files` to activate these transformations.

--- a/Segmentazione/CNN/Dataset.py
+++ b/Segmentazione/CNN/Dataset.py
@@ -46,17 +46,23 @@ def load_image_and_mask(image_path, mask_path, image_size, num_classes):
 
 
 def augment_data(image, mask):
-    """
-    Applica la stessa trasformazione casuale sia all'immagine che alla maschera.
-    """
-    # Per l'augmentation, la maschera ha di nuovo bisogno della dimensione del canale
+    """Applica trasformazioni random a immagine e maschera."""
     mask_with_channel = tf.expand_dims(mask, axis=-1)
 
     if tf.random.uniform(()) > 0.5:
         image = tf.image.flip_left_right(image)
         mask_with_channel = tf.image.flip_left_right(mask_with_channel)
+    if tf.random.uniform(()) > 0.5:
+        image = tf.image.flip_up_down(image)
+        mask_with_channel = tf.image.flip_up_down(mask_with_channel)
 
-    # Rimuovi di nuovo la dimensione del canale dalla maschera
+    k = tf.random.uniform([], minval=0, maxval=4, dtype=tf.int32)
+    image = tf.image.rot90(image, k)
+    mask_with_channel = tf.image.rot90(mask_with_channel, k)
+
+    image = tf.image.random_brightness(image, 0.2)
+    image = tf.image.random_contrast(image, 0.8, 1.2)
+
     mask = tf.squeeze(mask_with_channel, axis=-1)
 
     return image, mask

--- a/common/dataset_organization.py
+++ b/common/dataset_organization.py
@@ -13,6 +13,17 @@ from .data_utils import (
     remap_labels,
 )
 
+
+def augment_image(image, label):
+    """Random augmentations for classification images."""
+    k = tf.random.uniform([], minval=0, maxval=4, dtype=tf.int32)
+    image = tf.image.rot90(image, k)
+    image = tf.image.random_flip_left_right(image)
+    image = tf.image.random_flip_up_down(image)
+    image = tf.image.random_brightness(image, max_delta=0.2)
+    image = tf.image.random_contrast(image, 0.8, 1.2)
+    return image, label
+
 # === CONFIGURAZIONE ===
 # Percorso base relativo a questo file (cioè la root del progetto)
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -80,7 +91,7 @@ def show_images(ds, max_images=32):
 
 # === BLOCCO PRINCIPALE ===
 #Prepara e restituisce il train dataset ed il validation dataset
-def get_dataset(attributo):
+def get_dataset(attributo, augment=False):
 
     download_and_extract(DATASET_DIR, ZIP_NAME, GDRIVE_ID)  # Scarica ed estrae le immagini ESPERIMENTI se non già presenti
 
@@ -116,7 +127,13 @@ def get_dataset(attributo):
     if attributo == "id":
 
         train_dataset = balance_dataset(train_dataset)
-        train_dataset, validation_dataset = standardize_dataset(train_dataset, validation_dataset)
+        if augment:
+            train_dataset = train_dataset.map(
+                augment_image, num_parallel_calls=tf.data.AUTOTUNE
+            )
+        train_dataset, validation_dataset = standardize_dataset(
+            train_dataset, validation_dataset
+        )
 
         return train_dataset, validation_dataset
 
@@ -143,6 +160,10 @@ def get_dataset(attributo):
     if train_dataset is not None:
         print("🔁 Bilanciamento del dataset in corso...")
         train_dataset = balance_dataset(train_dataset)
+        if augment:
+            train_dataset = train_dataset.map(
+                augment_image, num_parallel_calls=tf.data.AUTOTUNE
+            )
 
     # Estrai le classi presenti nel dataset bilanciato
     from collections import Counter
@@ -164,7 +185,9 @@ def get_dataset(attributo):
 
 
     #viene calcolata la media e la deviazione standard delle immagini del training set
-    train_dataset, validation_dataset = standardize_dataset(train_dataset, validation_dataset)
+    train_dataset, validation_dataset = standardize_dataset(
+        train_dataset, validation_dataset
+    )
 
 
     #questo blocco visualizza le immagini


### PR DESCRIPTION
## Summary
- allow optional image augmentations in `get_dataset` via `augment` flag
- expand segmentation dataset augmentations with flips, rotations and brightness/contrast tweaks
- document new augmentation options in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b5348c4c8332be7f1a6c7d3e42ce